### PR TITLE
Avoid global mutable state

### DIFF
--- a/src/model.mli
+++ b/src/model.mli
@@ -25,7 +25,7 @@ module Make (Context : S.CONTEXT) : sig
   (** [version impl] is the Opam package for [impl], if any.
       Virtual and dummy implementations return [None]. *)
 
-  val virtual_role : impl list -> Role.t
+  val virtual_role : context:Context.t -> impl list -> Role.t
   (** [virtual_role impls] is a virtual package name with candidates [impls].
       This is used if the user requests multiple packages on the command line
       (the single [impl] will also be virtual). *)

--- a/src/s.ml
+++ b/src/s.ml
@@ -16,4 +16,6 @@ module type CONTEXT = sig
   val user_restrictions : t -> Cudf_types.pkgname -> (Cudf_types.relop * Cudf_types.version) list
   (** [user_restrictions t pkg] is the user's constraint on [pkg], if any. This is just
       used for diagnostics; you still have to filter them out yourself in [candidates]. *)
+
+  val fresh_id : t -> int
 end


### PR DESCRIPTION
This is useful in the case where the solver is called several times with the same program